### PR TITLE
Fine-tune indexing for large amount of data.  

### DIFF
--- a/IndexPlugin/MongoDBBackend.cpp
+++ b/IndexPlugin/MongoDBBackend.cpp
@@ -124,8 +124,10 @@ namespace OrthancPlugins
     db["Resources"].create_index(make_document(kvp("internalId", 1)));
     db["PatientRecyclingOrder"].create_index(make_document(kvp("patientId", 1)));
     db["MainDicomTags"].create_index(make_document(kvp("id", 1)));
+    db["MainDicomTags"].create_index(make_document(kvp("tagGroup", 1), kvp("tagElement", 1), kvp("value", 1)));
+    db["MainDicomTags"].create_index(make_document(kvp("value", 1)));
     db["DicomIdentifiers"].create_index(make_document(kvp("id", 1)));
-    db["DicomIdentifiers"].create_index(make_document(kvp("tagGroup", 1), kvp("tagElement", 1)));
+    db["DicomIdentifiers"].create_index(make_document(kvp("tagGroup", 1), kvp("tagElement", 1), kvp("value", 1)));
     db["DicomIdentifiers"].create_index(make_document(kvp("value", 1)));
     db["Changes"].create_index(make_document(kvp("internalId", 1)));
     db["AttachedFiles"].create_index(make_document(kvp("id", 1)));


### PR DESCRIPTION
Previously compound indexes were only available for DicomIdentifiers, these were adjusted and similar indexes were added to MainDicomTags. The resulting speed up allowed a failing use case to function.

Affects aggregate queries that lookup both DicomIdentifiers and MainDicomTags